### PR TITLE
Fixed issue with Wild Events Master Data page not showing in the left menu.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,6 +57,7 @@ module.exports = {
             "aquaculture-events/commodities"
           ],
           "Wild Events": [
+            "wild-events/master-data",
             "wild-events/fishing-events",
             "wild-events/on-vessel-processing",
             "wild-events/transshipment",


### PR DESCRIPTION
Fixed the gatsby-config.js so that it includes the Master Data page in the Wild Events section.

## 🎉 Issues resolved:

- closes #23 